### PR TITLE
Fix warnings

### DIFF
--- a/lib/domainatrex.ex
+++ b/lib/domainatrex.ex
@@ -4,12 +4,12 @@ defmodule Domainatrex do
   @moduledoc """
   Documentation for Domainatrex.
   """
-  @fallback_local_copy Application.get_env(
+  @fallback_local_copy Application.compile_env(
                          :domainatrex,
                          :fallback_local_copy,
                          "lib/public_suffix_list.dat"
                        )
-  @fetch_latest Application.get_env(:domainatrex, :fetch_latest, true)
+  @fetch_latest Application.compile_env(:domainatrex, :fetch_latest, true)
   @public_suffix_list nil
 
   :inets.start()
@@ -17,7 +17,7 @@ defmodule Domainatrex do
 
   with true <- @fetch_latest,
        public_suffix_list_url <-
-         Application.get_env(
+         Application.compile_env(
            :domainatrex,
            :public_suffix_list_url,
            'https://raw.githubusercontent.com/publicsuffix/list/master/public_suffix_list.dat'
@@ -45,11 +45,11 @@ defmodule Domainatrex do
       end
   end
 
-  custom_suffixes = Application.get_env(:domainatrex, :custom_suffixes, [])
+  custom_suffixes = Application.compile_env(:domainatrex, :custom_suffixes, [])
 
   string =
-    if Application.get_env(:domainatrex, :icann_only, false) or
-         Application.get_env(:domainatrex, :include_private, true) == false do
+    if Application.compile_env(:domainatrex, :icann_only, false) or
+         Application.compile_env(:domainatrex, :include_private, true) == false do
       @public_suffix_list
       |> String.split("// ===END ICANN DOMAINS===")
       |> List.first()

--- a/mix.exs
+++ b/mix.exs
@@ -20,7 +20,7 @@ defmodule Domainatrex.Mixfile do
   # Type "mix help compile.app" for more information
   def application do
     # Specify extra applications you'll use from Erlang/Elixir
-    [extra_applications: [:logger]]
+    [extra_applications: [:logger, :inets, :ssl]]
   end
 
   # Dependencies can be Hex packages:


### PR DESCRIPTION
Fix the following warnings when compiled in Elixir 1.14.3:

```elixir
==> domainatrex
Compiling 1 file (.ex)
warning: Application.get_env/3 is discouraged in the module body, use Application.compile_env/3 instead
Warning:   lib/domainatrex.ex:27: Domainatrex

Compiling lib/domainatrex.ex (it's taking more than 10s)
warning: :httpc.request/4 defined in application :inets is used by the current application but the current application does not depend on :inets. To fix this, you must do one of:

  1. If :inets is part of Erlang/Elixir, you must include it under :extra_applications inside "def application" in your mix.exs

  2. If :inets is a dependency, make sure it is listed under "def deps" in your mix.exs

  3. In case you don't want to add a requirement to :inets, you may optionally skip this warning by adding [xref: [exclude: [:httpc]]] to your "def project" in mix.exs

  lib/domainatrex.ex:12: Domainatrex

warning: :inets.start/0 defined in application :inets is used by the current application but the current application does not depend on :inets. To fix this, you must do one of:

  1. If :inets is part of Erlang/Elixir, you must include it under :extra_applications inside "def application" in your mix.exs

  2. If :inets is a dependency, make sure it is listed under "def deps" in your mix.exs

  3. In case you don't want to add a requirement to :inets, you may optionally skip this warning by adding [xref: [exclude: [:inets]]] to your "def project" in mix.exs

  lib/domainatrex.ex:9: Domainatrex
```