### PR TITLE
Fix International Domain Names

### DIFF
--- a/lib/domainatrex.ex
+++ b/lib/domainatrex.ex
@@ -38,8 +38,8 @@ defmodule Domainatrex do
            :public_suffix_list_url,
            ~c"https://publicsuffix.org/list/public_suffix_list.dat"
          ),
-       {:ok, {_, _, string}} <- :httpc.request(:get, {public_suffix_list_url, []}, [], []) do
-    @public_suffix_list to_string(string)
+       {:ok, {_, _, string}} <- :httpc.request(:get, {public_suffix_list_url, []}, [], [{:body_format, :binary}]) do
+    @public_suffix_list string
   else
     _ ->
       case File.read(@fallback_local_copy) do

--- a/test/domainatrex_advanced_test.exs
+++ b/test/domainatrex_advanced_test.exs
@@ -64,26 +64,22 @@ defmodule DomainatrexAdvancedTest do
   end
 
   test "internationalized domain names" do
-    # Test Internationalized Domain Names (IDN) 
-    # The library has mixed support for Unicode domains:
-    # - Latin-based scripts with diacritics (like German umlauts) work
-    # - Non-Latin scripts (like Chinese or Cyrillic) don't work
-    # This test documents the current behavior
+    # Test Internationalized Domain Names (IDN)
 
     # Example with German umlaut (works)
-    assert Domainatrex.parse("käse.de") == 
+    assert Domainatrex.parse("käse.de") ==
       {:ok, %{domain: "käse", subdomain: "", tld: "de"}}
 
-    # Example with Chinese characters (simplified) - doesn't work
-    assert Domainatrex.parse("例子.中国") == 
-      {:error, "Cannot match: invalid domain"}
+    # Example with Chinese characters (simplified)
+    assert Domainatrex.parse("例子.中国") ==
+      {:ok, %{domain: "例子", subdomain: "", tld: "中国"}}
 
-    # Example with Cyrillic (Russian) - doesn't work
-    assert Domainatrex.parse("пример.рф") == 
-      {:error, "Cannot match: invalid domain"}
+    # Example with Cyrillic (Russian)
+    assert Domainatrex.parse("пример.рф") ==
+      {:ok, %{domain: "пример", subdomain: "", tld: "рф"}}
 
-    # For full IDN support, domains should be converted to Punycode first
-    # For example: "例子.中国" would become "xn--fsq.xn--fiqs8s"
+    # For full IDN support, domains should be converted from punycode to Unicode first
+    # For example: "xn--fsq.xn--fiqs8s" needs to become "例子.中国"
   end
 
   test "domains with hyphens" do


### PR DESCRIPTION
I noticed that parsing didn't work with basically any Unicode domain. 

After investigating I noticed that when fetching the latest list, erlang was transforming the result to a char list and the unicode was lost in the process.

This fix tells erlang to keep the response body as a binary, which elixir already interprets correctly as UTF-8.